### PR TITLE
Add CI workflow to convert markdown into pdf and upload the artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install xelatex
+        run: sudo apt install texlive-xetex
+
+      - name: Install pandoc
+        run: sudo apt-get install pandoc
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Convert to pdf
+        run: make
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-kms-xksproxy-api-spec
+          path: ./build/*.pdf

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/aws/aws-kms-xksproxy-api-spec/actions/workflows/ci.yml/badge.svg)
+
 ## AWS KMS External Keystore (XKS) Proxy API Specification
 
 This repository contains the AWS KMS External Keystore (XKS) Proxy API Specification in markdown format, which can be used to generate a PDF file via [pandoc](https://pandoc.org/).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Creates a workflow to  to convert markdown into PDF and upload the artifact upon push or pull_request.

Sample workflow run:

  https://github.com/hansonchar/aws-kms-xksproxy-api-spec/actions/runs/3224338579

Sample artifact:

  https://github.com/hansonchar/aws-kms-xksproxy-api-spec/suites/8710063519/artifacts/393416369


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
